### PR TITLE
Git repo finder add folder commands

### DIFF
--- a/Utilities/GitRepoFinder/GitRepoFinder.csproj
+++ b/Utilities/GitRepoFinder/GitRepoFinder.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>1.0.2.0</AssemblyVersion>
+        <AssemblyVersion>1.1.1.0</AssemblyVersion>
         <ApplicationIcon>docs\icon.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Utilities/GitRepoFinder/GitRepoFinder.csproj
+++ b/Utilities/GitRepoFinder/GitRepoFinder.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="nac.Forms" Version="1.8.4" />
+      <PackageReference Include="nac.Forms" Version="1.9.1" />
         <PackageReference Include="Dotnet.Bundle" Version="*" />
     </ItemGroup>
 

--- a/Utilities/GitRepoFinder/models/EditCommandsWindowModel.cs
+++ b/Utilities/GitRepoFinder/models/EditCommandsWindowModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.ObjectModel;
+
+namespace GitRepoFinder.models;
+
+public class EditCommandsWindowModel : nac.Forms.model.ViewModelBase
+{
+    public ObservableCollection<models.FolderCommandModel> CommandList
+    {
+        get { return GetValue(() => CommandList); }
+    }
+}

--- a/Utilities/GitRepoFinder/models/FolderCommandModel.cs
+++ b/Utilities/GitRepoFinder/models/FolderCommandModel.cs
@@ -2,9 +2,16 @@ namespace GitRepoFinder.models;
 
 public class FolderCommandModel : nac.Forms.model.ViewModelBase
 {
-    public string CommandText
+
+    public string ExePath
     {
-        get { return GetValue(() => CommandText); }
-        set { SetValue(() => CommandText, value);}
+        get { return GetValue(() => ExePath); }
+        set { SetValue(() => ExePath, value);}
+    }
+    
+    public string Arguments
+    {
+        get { return GetValue(() => Arguments); }
+        set { SetValue(() => Arguments, value);}
     }
 }

--- a/Utilities/GitRepoFinder/models/FolderCommandModel.cs
+++ b/Utilities/GitRepoFinder/models/FolderCommandModel.cs
@@ -1,0 +1,10 @@
+namespace GitRepoFinder.models;
+
+public class FolderCommandModel : nac.Forms.model.ViewModelBase
+{
+    public string CommandText
+    {
+        get { return GetValue(() => CommandText); }
+        set { SetValue(() => CommandText, value);}
+    }
+}

--- a/Utilities/GitRepoFinder/models/FolderCommandModel.cs
+++ b/Utilities/GitRepoFinder/models/FolderCommandModel.cs
@@ -3,6 +3,12 @@ namespace GitRepoFinder.models;
 public class FolderCommandModel : nac.Forms.model.ViewModelBase
 {
 
+    public string Description
+    {
+        get { return GetValue(() => Description); }
+        set { SetValue(() => Description, value);}
+    }
+    
     public string ExePath
     {
         get { return GetValue(() => ExePath); }

--- a/Utilities/GitRepoFinder/models/SettingsFileModel.cs
+++ b/Utilities/GitRepoFinder/models/SettingsFileModel.cs
@@ -3,6 +3,7 @@
 public class SettingsFileModel
 {
     public List<string> workspaces { get; set; } = new();
-    
+
+    public List<FolderCommandModel> commands { get; set; } = new();
 
 }

--- a/Utilities/GitRepoFinder/repos/CommandsRepo.cs
+++ b/Utilities/GitRepoFinder/repos/CommandsRepo.cs
@@ -13,6 +13,16 @@ public static class CommandsRepo
         return tc.Task;
     }
 
+    public static async Task saveAll(IEnumerable<models.FolderCommandModel> commands)
+    {
+        var settings = repos.settingsFile.read();
+        
+        settings.commands.Clear();
+        settings.commands.AddRange(commands);
+        
+        repos.settingsFile.write(settings);
+    }
+
     public static Task Add(models.FolderCommandModel command)
     {
         var settings = repos.settingsFile.read();

--- a/Utilities/GitRepoFinder/repos/CommandsRepo.cs
+++ b/Utilities/GitRepoFinder/repos/CommandsRepo.cs
@@ -1,0 +1,33 @@
+namespace GitRepoFinder.repos;
+
+public static class CommandsRepo
+{
+    
+    public static Task<List<models.FolderCommandModel>> getAll()
+    {
+        var tc = new TaskCompletionSource<List<models.FolderCommandModel>>();
+
+        var settings = repos.settingsFile.read();
+        tc.SetResult(settings.commands);
+
+        return tc.Task;
+    }
+
+    public static Task Add(models.FolderCommandModel command)
+    {
+        var settings = repos.settingsFile.read();
+        settings.commands.Add(command);
+        repos.settingsFile.write(settings);
+        
+        return Task.CompletedTask;
+    }
+
+    public static Task Remove(models.FolderCommandModel command)
+    {
+        var settings = repos.settingsFile.read();
+        settings.commands.Remove(command);
+        repos.settingsFile.write(settings);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/Utilities/GitRepoFinder/repos/CommandsRepo.cs
+++ b/Utilities/GitRepoFinder/repos/CommandsRepo.cs
@@ -2,6 +2,8 @@ namespace GitRepoFinder.repos;
 
 public static class CommandsRepo
 {
+
+    private static List<models.FolderCommandModel> commandListCache;
     
     public static Task<List<models.FolderCommandModel>> getAll()
     {
@@ -39,5 +41,16 @@ public static class CommandsRepo
         repos.settingsFile.write(settings);
         
         return Task.CompletedTask;
+    }
+
+    public static async Task RefreshCommandListCache()
+    {
+        commandListCache = null;
+        commandListCache = await getAll();
+    }
+
+    public static List<models.FolderCommandModel> GetAllCached()
+    {
+        return commandListCache;
     }
 }

--- a/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
@@ -64,6 +64,8 @@ Command Placeholders - Can be used in the Args textbox
                         await repos.CommandsRepo.Remove(cmd);
                         model.CommandList.Remove(cmd);
                     })
+                    .Text("Desc: ")
+                    .TextBoxFor(nameof(cmd.Description), style: new Style{width = 50})
                     .Text("Exe: ")
                     .TextBoxFor(nameof(cmd.ExePath), style: new Style { width = 400 })
                     .Text("Args: ")

--- a/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
@@ -1,3 +1,5 @@
+using nac.Forms.model;
+
 namespace GitRepoFinder.repos;
 
 public class EditCommandsWindowRepo
@@ -26,6 +28,12 @@ public class EditCommandsWindowRepo
                 {
                     model.CommandList.Add(cmd);
                 }
+            }, onClosing: async (_f) =>
+            {
+                // save the commands
+                await repos.CommandsRepo.saveAll(model.CommandList);
+
+                return false; 
             });
     }
     
@@ -41,7 +49,7 @@ public class EditCommandsWindowRepo
             });
         })
             .Text(@"--------------------
-Command Placeholders
+Command Placeholders - Can be used in the Args textbox
 --------------------
 {folderpath} - Path, This is the path to the folder the git repo is in
 ####################
@@ -56,8 +64,10 @@ Command Placeholders
                         await repos.CommandsRepo.Remove(cmd);
                         model.CommandList.Remove(cmd);
                     })
-                    .Text("Command Text: ")
-                    .TextBoxFor(nameof(cmd.CommandText));
+                    .Text("Exe: ")
+                    .TextBoxFor(nameof(cmd.ExePath), style: new Style { width = 400 })
+                    .Text("Args: ")
+                    .TextBoxFor(nameof(cmd.Arguments), style: new Style { width = 400 });
             });
         });
     }

--- a/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
@@ -1,0 +1,57 @@
+namespace GitRepoFinder.repos;
+
+public class EditCommandsWindowRepo
+{
+    private static nac.Forms.Form myForm;
+    private static models.EditCommandsWindowModel model;
+
+
+    public static async Task run(nac.Forms.Form parentForm)
+    {
+        await parentForm.DisplayChildForm((_child) =>
+            {
+                myForm = _child;
+                model = new models.EditCommandsWindowModel();
+                myForm.DataContext = model;
+
+                myForm.Title = $"Edit Commands";
+            
+                buildAndDisplayUI();
+            }, useIsolatedModelForThisChildForm: true,
+            onDisplay: async (_f) =>
+            {
+                var existingCommands = await repos.CommandsRepo.getAll();
+                
+                foreach (var cmd in existingCommands)
+                {
+                    model.CommandList.Add(cmd);
+                }
+            });
+    }
+    
+    
+    
+    private static void buildAndDisplayUI()
+    {
+        myForm.HorizontalGroup(h =>
+        {
+            h.Button("Add", async () =>
+            {
+                model.CommandList.Add(new());
+            });
+        }).List<models.FolderCommandModel>(nameof(model.CommandList), itemRow =>
+        {
+            itemRow.HorizontalGroup(h =>
+            {
+                var cmd = itemRow.DataContext as models.FolderCommandModel;
+                h.Button("Delete", async () =>
+                    {
+                        await repos.CommandsRepo.Remove(cmd);
+                        model.CommandList.Remove(cmd);
+                    })
+                    .Text("Command Text: ")
+                    .TextBoxFor(nameof(cmd.CommandText));
+            });
+        });
+    }
+}

--- a/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
@@ -39,7 +39,14 @@ public class EditCommandsWindowRepo
             {
                 model.CommandList.Add(new());
             });
-        }).List<models.FolderCommandModel>(nameof(model.CommandList), itemRow =>
+        })
+            .Text(@"--------------------
+Command Placeholders
+--------------------
+{folderpath} - Path, This is the path to the folder the git repo is in
+####################
+            ")
+            .List<models.FolderCommandModel>(nameof(model.CommandList), itemRow =>
         {
             itemRow.HorizontalGroup(h =>
             {

--- a/Utilities/GitRepoFinder/repos/ErrorWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/ErrorWindowRepo.cs
@@ -1,0 +1,28 @@
+using Avalonia.Media;
+using nac.Forms;
+using nac.Forms.model;
+
+namespace GitRepoFinder.repos;
+
+public class ErrorWindowRepo
+{
+    public static void run(Form parentForm, Exception exception)
+    {
+        parentForm.DisplayChildForm(f =>
+            {
+                f.Model["details"] = exception.ToString();
+            
+            f.Text("An exception occured", style: new Style { foregroundColor = Colors.Red })
+                .TextBoxFor("details", 
+                    multiline:true,
+                    isReadOnly:true,
+                    style: new Style{height = 400})
+                .Button("ok", async () =>
+                {
+                    f.Close();
+                });
+
+        }, isDialog: true,
+            useIsolatedModelForThisChildForm: true);
+    }
+}

--- a/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
@@ -47,8 +47,8 @@ public static class MainWindowRepo
                                 Action = async () =>
                                 {
                                     await repos.EditCommandsWindowRepo.run(myForm);
-                                    await RefreshGitRepos();
                                     await repos.CommandsRepo.RefreshCommandListCache();
+                                    await RefreshGitRepos();
                                 }
                             }
                         }
@@ -100,8 +100,8 @@ public static class MainWindowRepo
         }, style: new Style{isVisibleModelName = nameof(model.doneGitRepoLoad)})
         .Display(onDisplay: async (_f) =>
         {
-            await RefreshGitRepos();
             await repos.CommandsRepo.RefreshCommandListCache();
+            await RefreshGitRepos();
         });
     }
 

--- a/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
@@ -36,6 +36,20 @@ public static class MainWindowRepo
                     {
                         await repos.EditWorkspacesWindowRepo.run(myForm);
                         await RefreshGitRepos();
+                    }, new Style
+                    {
+                        contextMenuItems = new nac.Forms.model.MenuItem[]
+                        {
+                            new nac.Forms.model.MenuItem
+                            {
+                                Header = "Edit Commands",
+                                Action = async () =>
+                                {
+                                    await repos.EditCommandsWindowRepo.run(myForm);
+                                    await RefreshGitRepos();
+                                }
+                            }
+                        }
                     });
             })
         .HorizontalGroup(h =>

--- a/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/MainWindowRepo.cs
@@ -113,21 +113,35 @@ public static class MainWindowRepo
         foreach (var c in cmdList)
         {
             var item = new nac.Forms.model.MenuItem();
-
-            string commandArguments = repos.StringFormat.OskarFormat(c.Arguments, new
-            {
-                filepath = repo.Path
-            });
-
+            
             item.Header = c.Description;
             item.Action = () =>
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(c.ExePath, commandArguments));
+                runCommand(repo, command: c);
             };
             items.Add(item);
         }
 
         return items.ToArray();
+    }
+
+    private static void runCommand(GitRepoInfo repo, FolderCommandModel command)
+    {
+        try
+        {
+            string commandArguments = repos.StringFormat.OskarFormat(command.Arguments, new
+            {
+                folderpath = repo.Path
+            });
+            
+            repos.log.Info($"Running command: EXE[{command.ExePath}] Arguments[{commandArguments}]");
+            
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(command.ExePath, commandArguments));
+        }
+        catch (Exception ex)
+        {
+            repos.ErrorWindowRepo.run(parentForm: myForm, exception: ex);
+        }
     }
 
     private static void FilterRepos()

--- a/Utilities/GitRepoFinder/repos/StringFormat.cs
+++ b/Utilities/GitRepoFinder/repos/StringFormat.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace GitRepoFinder.repos;
+
+public static class StringFormat
+{
+    // from: https://github.com/tallesl/net-Interpolate/blob/master/Library/OskarFormatter.cs
+    
+    public static string OskarFormat(this string format, object arguments)
+    {
+        Hashtable attributes = GetPropertyHash(arguments);
+
+        string result = format;
+        if (attributes == null || format == null)
+            return result;
+
+        foreach (string attributeKey in attributes.Keys)
+        {
+            result = result.InjectSingleValue(attributeKey, attributes[attributeKey]);
+        }
+        return result;
+    }
+
+    private static string InjectSingleValue(this string format, string key, object replacementValue)
+    {
+        string result = format;
+        //regex replacement of key with value, where the generic key format is:
+        //Regex foo = new Regex("{(foo)(?:}|(?::(.[^}]*)}))");
+        Regex attributeRegex = new Regex("{(" + key + ")(?:}|(?::(.[^}]*)}))");  //for key = foo, matches {foo} and {foo:SomeFormat}
+
+        //loop through matches, since each key may be used more than once (and with a different format string)
+        foreach (Match m in attributeRegex.Matches(format))
+        {
+            string replacement = m.ToString();
+            if (m.Groups[2].Length > 0) //matched {foo:SomeFormat}
+            {
+                //do a double string.Format - first to build the proper format string, and then to format the replacement value
+                string attributeFormatString = string.Format(CultureInfo.InvariantCulture, "{{0:{0}}}", m.Groups[2]);
+                replacement = string.Format(CultureInfo.CurrentCulture, attributeFormatString, replacementValue);
+            }
+            else //matched {foo}
+            {
+                replacement = (replacementValue ?? string.Empty).ToString();
+            }
+            //perform replacements, one match at a time
+            result = result.Replace(m.ToString(), replacement);  //attributeRegex.Replace(result, replacement, 1);
+        }
+        return result;
+    }
+
+    private static Hashtable GetPropertyHash(object properties)
+    {
+        Hashtable values = null;
+        if (properties != null)
+        {
+            values = new Hashtable();
+            PropertyDescriptorCollection props = TypeDescriptor.GetProperties(properties);
+            foreach (PropertyDescriptor prop in props)
+            {
+                values.Add(prop.Name, prop.GetValue(properties));
+            }
+        }
+        return values;
+    }
+}

--- a/Utilities/GitRepoFinder/repos/WorkspacesRepo.cs
+++ b/Utilities/GitRepoFinder/repos/WorkspacesRepo.cs
@@ -2,8 +2,6 @@
 
 public static class WorkspacesRepo
 {
-    private static List<string> workspaces = new();
-
 
     public static Task<List<string>> getAll()
     {

--- a/Utilities/GitRepoFinder/repos/log.cs
+++ b/Utilities/GitRepoFinder/repos/log.cs
@@ -2,11 +2,41 @@
 
 public static class log
 {
-    public static void Error(string message)
+    private static void writeToConsole(string level, string message, System.ConsoleColor color)
     {
         var previous = System.Console.ForegroundColor;
-        System.Console.ForegroundColor = ConsoleColor.Red;
-        System.Console.WriteLine($"[{DateTime.Now}] - [ERROR] - {message}");
-        System.Console.ForegroundColor = previous;
+        System.Console.ForegroundColor = color;
+        System.Console.WriteLine($"[{DateTime.Now}] - [{level}] - {message}");
+        System.Console.ForegroundColor = previous; 
+    }
+
+
+    private static void writeToFile(string level, string message)
+    {
+        string logFilePath = System.IO.Path.Combine(System.AppContext.BaseDirectory, $"log{DateTime.Now:yyyyMMdd}.txt");
+        
+        using (FileStream fs = System.IO.File.Open(logFilePath,
+                   mode: System.IO.FileMode.Append,
+                   access: System.IO.FileAccess.Write,
+                   share: System.IO.FileShare.ReadWrite | System.IO.FileShare.Delete)) {
+            using( var writer = new StreamWriter(fs))
+            {
+                string entry = $"[{DateTime.Now}] - [{level}] - {message}";
+                writer.WriteLine(entry);
+            }
+        }
+    }
+    
+    public static void Error(string message)
+    {
+        writeToConsole("ERROR", message, ConsoleColor.Red);
+        writeToFile("ERROR", message);
+    }
+
+
+    public static void Info(string message)
+    {
+        writeToConsole("INFO", message, System.Console.ForegroundColor);
+        writeToFile("INFO", message);
     }
 }


### PR DESCRIPTION

Create a way to run commands on a folder quickly.  We need this to be able to launch gittyup, phpstorm, rider, and other programs against the folder

This is related to issue: https://github.com/NathanielACollier/repl_csharp_sln/issues/1