### PR TITLE
GitRepoFinder - Bug - Deleting command crashes

### DIFF
--- a/Utilities/GitRepoFinder/repos/CommandsRepo.cs
+++ b/Utilities/GitRepoFinder/repos/CommandsRepo.cs
@@ -7,31 +7,32 @@ public static class CommandsRepo
     
     public static Task<List<models.FolderCommandModel>> getAll()
     {
-        var tc = new TaskCompletionSource<List<models.FolderCommandModel>>();
-
-        var settings = repos.settingsFile.read();
-        tc.SetResult(settings.commands);
-
-        return tc.Task;
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            return settings.commands;
+        });
     }
 
-    public static async Task saveAll(IEnumerable<models.FolderCommandModel> commands)
+    public static Task saveAll(IEnumerable<models.FolderCommandModel> commands)
     {
-        var settings = repos.settingsFile.read();
-        
-        settings.commands.Clear();
-        settings.commands.AddRange(commands);
-        
-        repos.settingsFile.write(settings);
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            
+            settings.commands.Clear();
+            settings.commands.AddRange(commands);
+            
+            repos.settingsFile.write(settings);
+        });
     }
 
     public static Task Add(models.FolderCommandModel command)
     {
-        var settings = repos.settingsFile.read();
-        settings.commands.Add(command);
-        repos.settingsFile.write(settings);
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            settings.commands.Add(command);
+            repos.settingsFile.write(settings);
         
-        return Task.CompletedTask;
+        });
     }
 
     public static Task Remove(models.FolderCommandModel command)

--- a/Utilities/GitRepoFinder/repos/CommandsRepo.cs
+++ b/Utilities/GitRepoFinder/repos/CommandsRepo.cs
@@ -36,11 +36,12 @@ public static class CommandsRepo
 
     public static Task Remove(models.FolderCommandModel command)
     {
-        var settings = repos.settingsFile.read();
-        settings.commands.Remove(command);
-        repos.settingsFile.write(settings);
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            settings.commands.Remove(command);
+            repos.settingsFile.write(settings);
         
-        return Task.CompletedTask;
+        });
     }
 
     public static async Task RefreshCommandListCache()

--- a/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditCommandsWindowRepo.cs
@@ -59,6 +59,12 @@ Command Placeholders - Can be used in the Args textbox
             itemRow.HorizontalGroup(h =>
             {
                 var cmd = itemRow.DataContext as models.FolderCommandModel;
+
+                // when delete happens the DataContext is becoming null and breaking this
+                if( cmd == null ){
+                    return;
+                }
+
                 h.Button("Delete", async () =>
                     {
                         await repos.CommandsRepo.Remove(cmd);

--- a/Utilities/GitRepoFinder/repos/EditWorkspacesWindowRepo.cs
+++ b/Utilities/GitRepoFinder/repos/EditWorkspacesWindowRepo.cs
@@ -55,6 +55,12 @@ public class EditWorkspacesWindowRepo
             itemRow.HorizontalGroup(h =>
             {
                 var ws = itemRow.DataContext as models.WorkspaceModel;
+
+                // This can be null if you delete a workspace
+                if( ws == null ){
+                    return; 
+                }
+
                 h.Button("Delete", async () =>
                 {
                     await repos.WorkspacesRepo.RemoveWorkspace(ws.Path);

--- a/Utilities/GitRepoFinder/repos/WorkspacesRepo.cs
+++ b/Utilities/GitRepoFinder/repos/WorkspacesRepo.cs
@@ -5,30 +5,28 @@ public static class WorkspacesRepo
 
     public static Task<List<string>> getAll()
     {
-        var tc = new TaskCompletionSource<List<string>>();
-
-        var settings = repos.settingsFile.read();
-        tc.SetResult(settings.workspaces);
-
-        return tc.Task;
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            return settings.workspaces;
+        });
     }
 
     public static Task AddWorkspace(string workspacePath)
     {
-        var settings = repos.settingsFile.read();
-        settings.workspaces.Add(workspacePath);
-        repos.settingsFile.write(settings);
-        
-        return Task.CompletedTask;
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            settings.workspaces.Add(workspacePath);
+            repos.settingsFile.write(settings);
+        });
     }
 
     public static Task RemoveWorkspace(string workspacePath)
     {
-        var settings = repos.settingsFile.read();
-        settings.workspaces.Remove(workspacePath);
-        repos.settingsFile.write(settings);
-        
-        return Task.CompletedTask;
+        return Task.Run(() => {
+            var settings = repos.settingsFile.read();
+            settings.workspaces.Remove(workspacePath);
+            repos.settingsFile.write(settings);
+        });
     }
 
 


### PR DESCRIPTION
Deleting a command crashes
+ The command row becomes null, and then it crashes trying to render the null row